### PR TITLE
Custom ICloneable<T> interface

### DIFF
--- a/IdelPog/Engine/Repository/Repository.cs
+++ b/IdelPog/Engine/Repository/Repository.cs
@@ -1,9 +1,10 @@
-﻿using IdelPog.Engine.Validation.Pipelines;
+﻿using IdelPog.Engine.Structures.Types;
+using IdelPog.Engine.Validation.Pipelines;
 
 namespace IdelPog.Engine.Repository
 {
     public sealed class Repository<TID, T>(IRepositoryAsserter repositoryAsserter) : IRepository<TID, T>
-        where T : class, ICloneable where TID : notnull
+        where T : class, ICloneable<T> where TID : notnull
     {
         private readonly Dictionary<TID, T> _repository = new();
 
@@ -35,8 +36,7 @@ namespace IdelPog.Engine.Repository
         {
             AssertKeyExists(key);
             
-            // TODO: instead of the cast would be better if we made our own cloneable interface
-            T entity = _repository[key].Clone() as T;
+            T entity = _repository[key].Clone();
             
             OnGet(key.GetHashCode(), entity);
             return entity;

--- a/IdelPog/Engine/Structures/Models/Currency.cs
+++ b/IdelPog/Engine/Structures/Models/Currency.cs
@@ -1,11 +1,12 @@
 ﻿using IdelPog.Engine.Structures.Enums;
+using IdelPog.Engine.Structures.Types;
 
 namespace IdelPog.Engine.Structures.Models
 {
     /// <summary>
     /// The Currency model.
     /// </summary>
-    public class Currency(CurrencyType currencyType, int amount = 0) : ICloneable
+    public class Currency(CurrencyType currencyType, int amount = 0) : ICloneable<Currency>
     {
         public readonly CurrencyType CurrencyType = currencyType;
         public int Amount { get; private set; } = amount;
@@ -15,7 +16,7 @@ namespace IdelPog.Engine.Structures.Models
             Amount = amount;
         }
 
-        public object Clone()
+        public Currency Clone()
         {
             return new Currency(CurrencyType, Amount);
         }

--- a/IdelPog/Engine/Structures/Models/Item.cs
+++ b/IdelPog/Engine/Structures/Models/Item.cs
@@ -9,7 +9,7 @@ namespace IdelPog.Engine.Structures.Models
     /// <seealso cref="AddAmount"/>
     /// <seealso cref="RemoveAmount"/>
     public class Item(InventoryID id, Information information, int sellPrice, int amount = 1)
-        : ICloneable
+        : ICloneable<Item>
     {
         public readonly InventoryID ID = id;
         public readonly Information Information = information;
@@ -27,7 +27,7 @@ namespace IdelPog.Engine.Structures.Models
             Amount -= amount;
         }
 
-        public object Clone()
+        public Item Clone()
         {
             return new Item(ID, Information, SellPrice, Amount);
         }

--- a/IdelPog/Engine/Structures/Models/Job.cs
+++ b/IdelPog/Engine/Structures/Models/Job.cs
@@ -6,13 +6,13 @@ namespace IdelPog.Engine.Structures.Models
     /// <summary>
     /// The Job model
     /// </summary>
-    public sealed class Job(ILevelable levelable, JobType jobType, Information information) : ICloneable
+    public sealed class Job(ILevelable levelable, JobType jobType, Information information) : ICloneable<Job>
     {
         public readonly ILevelable Levelable = levelable;
         public readonly Information Information = information;
         public readonly JobType JobType = jobType;
 
-        public object Clone()
+        public Job Clone()
         {
             return new Job(Levelable, JobType, Information);
         }

--- a/IdelPog/Engine/Structures/Types/ICloneable.cs
+++ b/IdelPog/Engine/Structures/Types/ICloneable.cs
@@ -1,0 +1,12 @@
+﻿namespace IdelPog.Engine.Structures.Types
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <seealso cref="Clone"/>
+    public interface ICloneable<out T>
+    {
+        public T Clone();
+    }
+}

--- a/IdelPog/Engine/Structures/Types/ICloneable.cs
+++ b/IdelPog/Engine/Structures/Types/ICloneable.cs
@@ -1,12 +1,16 @@
 ﻿namespace IdelPog.Engine.Structures.Types
 {
     /// <summary>
-    /// 
+    /// <see cref="ICloneable"/> but will return the actual object type
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of the object to be returned</typeparam>
     /// <seealso cref="Clone"/>
     public interface ICloneable<out T>
     {
+        /// <summary>
+        /// Clone an object and return it as the type of T
+        /// </summary>
+        /// <returns>The cloned object of type T</returns>
         public T Clone();
     }
 }

--- a/IdelPogTests/Repository/HookHandler.cs
+++ b/IdelPogTests/Repository/HookHandler.cs
@@ -1,4 +1,5 @@
 ﻿using IdelPog.Engine.Repository;
+using IdelPog.Engine.Structures.Models;
 using IdelPog.Engine.Validation.Assertions;
 using IdelPog.Engine.Validation.Assertions.Handlers;
 using IdelPog.Engine.Validation.Pipelines;
@@ -7,7 +8,7 @@ namespace IdelPogTests.Repository
 {
     public class HookHandler
     {
-        protected IRepository<int, string> TestRepository;
+        protected IRepository<int, Currency> TestRepository;
 
         protected bool AddEventTriggered;
         protected bool RemoveEventTriggered;
@@ -20,7 +21,7 @@ namespace IdelPogTests.Repository
         {
             IHandler handler = new ThrowHandler();
             IRepositoryAsserter repositoryAsserter = new RepositoryAsserter(new AssertFound(handler), new AssertNotNull(handler), new AssertNonDuplicate(handler));
-            TestRepository = new Repository<int, string>(repositoryAsserter);
+            TestRepository = new Repository<int, Currency>(repositoryAsserter);
             
             AddEventTriggered = false;
             RemoveEventTriggered = false;
@@ -35,22 +36,22 @@ namespace IdelPogTests.Repository
             TestRepository.OnContains += OnContains;
         }
 
-        private void OnAdd(int key, string value)
+        private void OnAdd(int key, Currency value)
         {
             AddEventTriggered = true;
         }
 
-        private void OnRemove(int key, string value)
+        private void OnRemove(int key, Currency value)
         {
             RemoveEventTriggered = true;
         }
 
-        private void OnGet(int key, string value)
+        private void OnGet(int key, Currency value)
         {
             GetEventTriggered = true;
         }
 
-        private void OnUpdate(string originalValue, string value)
+        private void OnUpdate(Currency originalValue, Currency value)
         {
             UpdateEventTriggered = true;
         }

--- a/IdelPogTests/Repository/RepositoryHooksTest.cs
+++ b/IdelPogTests/Repository/RepositoryHooksTest.cs
@@ -1,15 +1,24 @@
-﻿namespace IdelPogTests.Repository
+﻿using IdelPog.Engine.Structures.Models;
+using IdelPogTests.Utils;
+
+namespace IdelPogTests.Repository
 {
     [TestFixture]
     public class RepositoryHooksTest : HookHandler
     {
         private const int KEY = 1;
-        private const string VALUE = "VALUE";
-       
+        private Currency _currency { get; set; }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _currency = CurrencyFactory.CreateWood();
+        }
+        
         [Test]
         public void Positive_Add_CallsOAdd()
         {
-            TestRepository.Add(KEY, VALUE);
+            TestRepository.Add(KEY, _currency);
 
             Assert.That(AddEventTriggered, Is.True);
         }
@@ -17,7 +26,7 @@
         [Test]
         public void Positive_Remove_CallsOnRemove()
         {            
-            TestRepository.Add(KEY, VALUE);
+            TestRepository.Add(KEY, _currency);
 
             TestRepository.Remove(KEY);
 
@@ -27,9 +36,9 @@
         [Test]
         public void Positive_Update_CallsOnUpdate()
         {
-            TestRepository.Add(KEY, VALUE);
+            TestRepository.Add(KEY, _currency);
 
-            TestRepository.Update(KEY, VALUE);
+            TestRepository.Update(KEY, _currency);
 
             Assert.That(UpdateEventTriggered, Is.True);
         }
@@ -45,7 +54,7 @@
         [Test]
         public void Positive_Get_CallsOnGet()
         {
-            TestRepository.Add(KEY, VALUE);
+            TestRepository.Add(KEY, _currency);
 
             TestRepository.Get(KEY);
             

--- a/IdelPogTests/Repository/RepositoryTest.cs
+++ b/IdelPogTests/Repository/RepositoryTest.cs
@@ -1,6 +1,9 @@
 ﻿using IdelPog.Engine.Repository;
+using IdelPog.Engine.Structures.Models;
+using IdelPog.Engine.Utilities.Builders;
 using IdelPog.Engine.Validation.Exceptions;
 using IdelPog.Engine.Validation.Pipelines;
+using IdelPogTests.Utils;
 using Moq;
 
 namespace IdelPogTests.Repository
@@ -8,35 +11,45 @@ namespace IdelPogTests.Repository
     [TestFixture]
     public class RepositoryTest
     {
-        private IRepository<int, string> _repository;
+        private IRepository<int, Currency> _repository;
         private Mock<IRepositoryAsserter> _repositoryAsserterMock;
 
-        private const string VALUE = "TEST STRING";
+        private Currency _currency { get; set; }
         private const int KEY = 1;
 
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _currency = CurrencyFactory.CreateFood();
+        }
+        
         [SetUp]
         public void Setup()
         {
             _repositoryAsserterMock = new Mock<IRepositoryAsserter>();
-            _repository = new Repository<int, string>(_repositoryAsserterMock.Object);
+            _repository = new Repository<int, Currency>(_repositoryAsserterMock.Object);
         }
        
         [Test]
         public void Positive_Add_AddsItem()
         {
-            _repository.Add(KEY, VALUE);
+            _repository.Add(KEY, _currency);
             
-            string returnedString = _repository.Get(KEY);
-            Assert.That(VALUE, Is.EqualTo(returnedString));
+            Currency returnedCurrency = _repository.Get(KEY);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_currency.Amount, Is.EqualTo(returnedCurrency.Amount));
+                Assert.That(_currency.CurrencyType, Is.EqualTo(returnedCurrency.CurrencyType));
+            });
         }
 
         [Test]
         public void Negative_Add_DuplicateKey_Throws()
         {
-            _repositoryAsserterMock.Setup(library => library.AssertUnique(VALUE, It.IsAny<Func<bool>>()))
+            _repositoryAsserterMock.Setup(library => library.AssertUnique(_currency, It.IsAny<Func<bool>>()))
                 .Throws(new DuplicateItemException(KEY));
             
-            Assert.Throws<DuplicateItemException>(() => _repository.Add(KEY, VALUE));
+            Assert.Throws<DuplicateItemException>(() => _repository.Add(KEY, _currency));
         }
 
         [Test]
@@ -51,7 +64,7 @@ namespace IdelPogTests.Repository
         [Test]
         public void Positive_Remove_RemovesItem()
         {
-            _repository.Add(KEY, VALUE);
+            _repository.Add(KEY, _currency);
             _repository.Remove(KEY);
             
             bool contains = _repository.Contains(KEY);
@@ -70,10 +83,14 @@ namespace IdelPogTests.Repository
         [Test]
         public void Positive_Get_ReturnsItem()
         {
-            _repository.Add(KEY, VALUE);
+            _repository.Add(KEY, _currency);
             
-            string returnedString = _repository.Get(KEY);
-            Assert.That(VALUE, Is.EqualTo(returnedString));
+            Currency returnedCurrency = _repository.Get(KEY);
+            Assert.Multiple(() =>
+            {
+                Assert.That(_currency.Amount, Is.EqualTo(returnedCurrency.Amount));
+                Assert.That(_currency.CurrencyType, Is.EqualTo(returnedCurrency.CurrencyType));
+            });
         }
 
         [Test]
@@ -88,13 +105,20 @@ namespace IdelPogTests.Repository
         [Test]
         public void Positive_Update_UpdatesItem()
         {
-            _repository.Add(KEY, VALUE);
-            const string newValue = "CHANGED";
+            _repository.Add(KEY, _currency);
+            Currency newCurrency = CurrencyBuilder.Builder()
+                .Amount(100)
+                .CurrencyType(_currency.CurrencyType)
+                .Build();
             
-            _repository.Update(KEY, newValue);
+            _repository.Update(KEY, newCurrency);
             
-            string returnedString = _repository.Get(KEY);
-            Assert.That(newValue, Is.EqualTo(returnedString));
+            Currency returnedCurrency = _repository.Get(KEY);
+            Assert.Multiple(() =>
+            {
+                Assert.That(newCurrency.Amount, Is.EqualTo(returnedCurrency.Amount));
+                Assert.That(newCurrency.CurrencyType, Is.EqualTo(returnedCurrency.CurrencyType));
+            });
         }
 
         [Test]
@@ -103,7 +127,7 @@ namespace IdelPogTests.Repository
             _repositoryAsserterMock.Setup(library => library.AssertFound(KEY, It.IsAny<Func<bool>>()))
                 .Throws(new NotFoundException(KEY));
             
-            Assert.Throws<NotFoundException>(() => _repository.Update(KEY, VALUE));
+            Assert.Throws<NotFoundException>(() => _repository.Update(KEY, _currency));
         }
 
         [Test]
@@ -118,7 +142,7 @@ namespace IdelPogTests.Repository
         [Test]
         public void Positive_Contains_ReturnsTrue()
         {
-            _repository.Add(KEY, VALUE);
+            _repository.Add(KEY, _currency);
             
             bool  contains = _repository.Contains(KEY);
             


### PR DESCRIPTION
C#'s ICloneable.Clone() returns an object. To use this within the Repository we had to cast it to T, this was cringe. Now, ICloneable<T> will return the type of T. No more casting.