### PR TITLE
QueueComponentStore TryPeek

### DIFF
--- a/Modules/HarvestNode/ContentEngineBootstrapper.cs
+++ b/Modules/HarvestNode/ContentEngineBootstrapper.cs
@@ -178,7 +178,7 @@ namespace IdelPog.HarvestNode
             IFoundAssertion foundAssertion = new FoundAssertion();
             ICanUnlockAssertion<SkillID, HarvestNodeUnlockResponse> canUnlockAssertion = new CanUnlockAssertion<SkillID, HarvestNodeUnlockResponse>();
             IIDMatchesAssertion<SkillID> iidMatchesAssertion = new IDMatchesAssertion<SkillID>();
-            IQueueAssertion<SkillID, HarvestNodeUnlockResponse> queueAssertion = new QueueAssertion<SkillID, HarvestNodeUnlockResponse>();
+            IQueueAssertion queueAssertion = new QueueAssertion();
 
             IEntityUnlockerService<SkillID, HarvestNodeUnlockResponse> entityUnlockerService = new EntityUnlockerService<SkillID, HarvestNodeUnlockResponse>(entityRepository, foundAssertion, canUnlockAssertion, iidMatchesAssertion, queueAssertion);
             IDispatchMany<HarvestNodeUnlockResponse> responseDispatcher = new ManagedDispatcher<HarvestNodeUnlockResponse>(bufferManager, bufferLogger, objectNullAssertion, collectionAssertion);

--- a/Modules/HarvestNode/Contracts/Command/LocationLootCreation.cs
+++ b/Modules/HarvestNode/Contracts/Command/LocationLootCreation.cs
@@ -5,7 +5,6 @@ namespace IdelPog.HarvestNode.Contracts.Command
     public readonly record struct LocationLootCreation
     {
         public required LocationID LocationID { get; init; }
-        public required ResourceID ResourceID { get; init; }
         public required LootTableEntry[] LootTableEntries { get; init; }
         public required GrantPolicyEntry GrantPolicyEntry { get; init; }
     }

--- a/Modules/HarvestNode/Contracts/Response/LocationLootCreationResponse.cs
+++ b/Modules/HarvestNode/Contracts/Response/LocationLootCreationResponse.cs
@@ -4,7 +4,6 @@ namespace IdelPog.HarvestNode.Contracts.Response
 {
     public readonly record struct LocationLootCreationResponse
     {
-        public required ResourceID ResourceID { get; init; }
         public required LocationID LocationID { get; init; }
         public required LootTableEntry[] LootTableEntries { get; init; }
     }

--- a/Modules/HarvestNode/Runtime/Mediator/LocationLootCreationMediator.cs
+++ b/Modules/HarvestNode/Runtime/Mediator/LocationLootCreationMediator.cs
@@ -37,7 +37,7 @@ namespace IdelPog.HarvestNode.Runtime.Mediator
                 _lootTableService.CreateLootTable(creation.LootTableEntries, creation.LocationID);
                 _grantPolicyService.CreateGrantPolicy(creation.GrantPolicyEntry, creation.LocationID);
                 
-                LocationLootCreationResponse response = new() { ResourceID = creation.ResourceID, LocationID = creation.LocationID, LootTableEntries = creation.LootTableEntries };
+                LocationLootCreationResponse response = new() { LocationID = creation.LocationID, LootTableEntries = creation.LootTableEntries };
                 responses[i] = response;
             }
             

--- a/Progression/Assertion/Interface/IQueueAssertion.cs
+++ b/Progression/Assertion/Interface/IQueueAssertion.cs
@@ -1,9 +1,9 @@
-﻿using IdelPog.Progression.Runtime.Component;
-
-namespace IdelPog.Progression.Assertion.Interface
+﻿namespace IdelPog.Progression.Assertion.Interface
 {
-    public interface IQueueAssertion<TID, TCommand> where TCommand : struct
+    public interface IQueueAssertion
     {
-        public void AssertSuccessfulDequeue(bool successfulDequeue, LevelRequirementComponent<TID, TCommand> levelRequirementComponent);
+        public void AssertSuccessfulDequeue(bool successfulDequeue);
+
+        public void AssertSuccessfulPeek(bool successfulPeek);
     }
 }

--- a/Progression/Assertion/QueueAssertion.cs
+++ b/Progression/Assertion/QueueAssertion.cs
@@ -1,16 +1,23 @@
 ﻿using IdelPog.Progression.Assertion.Interface;
 using IdelPog.Progression.Exceptions;
-using IdelPog.Progression.Runtime.Component;
 
 namespace IdelPog.Progression.Assertion
 {
-    public sealed class QueueAssertion<TID, TCommand> : IQueueAssertion<TID, TCommand> where TCommand : struct
+    public sealed class QueueAssertion : IQueueAssertion
     {
-        public void AssertSuccessfulDequeue(bool successfulDequeue, LevelRequirementComponent<TID, TCommand> levelRequirementComponent)
+        public void AssertSuccessfulDequeue(bool successfulDequeue)
         {
             if (successfulDequeue == false)
             {
-                throw new UnsuccessfulDequeueException<TID, TCommand>(levelRequirementComponent);
+                throw new UnsuccessfulDequeueException();
+            }
+        }
+
+        public void AssertSuccessfulPeek(bool successfulPeek)
+        {
+            if (successfulPeek == false)
+            {
+                throw new UnsuccessfulPeekException();
             }
         }
     }

--- a/Progression/Exceptions/UnsuccessfulDequeueException.cs
+++ b/Progression/Exceptions/UnsuccessfulDequeueException.cs
@@ -1,16 +1,11 @@
-﻿using IdelPog.Progression.Runtime.Component;
-
-namespace IdelPog.Progression.Exceptions
+﻿namespace IdelPog.Progression.Exceptions
 {
-    public sealed class UnsuccessfulDequeueException<TID, TCommand> : Exception where TCommand : struct
+    public sealed class UnsuccessfulDequeueException : Exception
     {
         private const string MESSAGE = "Could not dequeue component!";
-        
-        public readonly LevelRequirementComponent<TID, TCommand> LevelRequirementComponent;
 
-        public UnsuccessfulDequeueException(LevelRequirementComponent<TID, TCommand> levelRequirementComponent) : base(string.Format(MESSAGE))
-        { 
-            LevelRequirementComponent = levelRequirementComponent;
+        public UnsuccessfulDequeueException() : base(string.Format(MESSAGE))
+        {
         }
     }
 }

--- a/Progression/Exceptions/UnsuccessfulPeekException.cs
+++ b/Progression/Exceptions/UnsuccessfulPeekException.cs
@@ -1,0 +1,11 @@
+﻿namespace IdelPog.Progression.Exceptions
+{
+    public sealed class UnsuccessfulPeekException : Exception
+    {
+        private const string MESSAGE = "Could not Peek!";
+
+        public UnsuccessfulPeekException() : base(string.Format(MESSAGE))
+        {
+        }
+    }
+}

--- a/Progression/Runtime/Component/QueueComponentStore.cs
+++ b/Progression/Runtime/Component/QueueComponentStore.cs
@@ -20,6 +20,11 @@ namespace IdelPog.Progression.Runtime.Component
             return _components.Peek();
         }
 
+        public bool TryPeek(out T component)
+        {
+            return _components.TryPeek(out component);
+        }
+
         public bool TryDequeue(out T component)
         {
             if (_components.Count <= 0)

--- a/Progression/Runtime/System/EntityUnlockerService.cs
+++ b/Progression/Runtime/System/EntityUnlockerService.cs
@@ -56,7 +56,10 @@ namespace IdelPog.Progression.Runtime.System
 
         private bool CanUnlockComponent(TID id, byte skillLevel, UnlockRequirementsEntity<TID, TCommand> entity)
         {
-            LevelRequirementComponent<TID, TCommand> firstComponent = GetFirstComponent(entity, id);
+            if (GetFirstComponent(entity, id, out LevelRequirementComponent<TID, TCommand> firstComponent) == false)
+            {
+                return false;
+            }
             
             bool canUnlock = skillLevel >= firstComponent.Level;
             return canUnlock;
@@ -64,7 +67,11 @@ namespace IdelPog.Progression.Runtime.System
 
         private TCommand DequeueComponent(TID id, byte skillLevel, UnlockRequirementsEntity<TID, TCommand> entity)
         {
-            LevelRequirementComponent<TID, TCommand> firstComponent = GetFirstComponent(entity, id);
+            bool hasFirst = GetFirstComponent(entity, id, out LevelRequirementComponent<TID, TCommand> firstComponent);
+            if (hasFirst == false)
+            {
+                throw new InvalidOperationException();
+            }
             
             _canUnlockAssertion.AssertCanUnlock(skillLevel, firstComponent.Level, firstComponent);
             
@@ -80,12 +87,16 @@ namespace IdelPog.Progression.Runtime.System
             
         }
 
-        private LevelRequirementComponent<TID, TCommand> GetFirstComponent(UnlockRequirementsEntity<TID, TCommand> entity, TID id)
+        private bool GetFirstComponent(UnlockRequirementsEntity<TID, TCommand> entity, TID id, out LevelRequirementComponent<TID, TCommand> component)
         {
-            LevelRequirementComponent<TID, TCommand> firstComponent = entity.Peek();
-            _idMatchesAssertion.AssertIDMatches(id, firstComponent.ID);
+            if (entity.TryPeek(out component) == false)
+            {
+                return false;
+            }
+            
+            _idMatchesAssertion.AssertIDMatches(id, component.ID);
 
-            return firstComponent;
+            return true;
         }
     }
 }

--- a/Progression/Runtime/System/EntityUnlockerService.cs
+++ b/Progression/Runtime/System/EntityUnlockerService.cs
@@ -12,9 +12,9 @@ namespace IdelPog.Progression.Runtime.System
         private readonly IFoundAssertion _foundAssertion;
         private readonly IIDMatchesAssertion<TID> _idMatchesAssertion;
         private readonly ICanUnlockAssertion<TID, TCommand> _canUnlockAssertion;
-        private readonly IQueueAssertion<TID, TCommand> _queueAssertion;
+        private readonly IQueueAssertion _queueAssertion;
 
-        public EntityUnlockerService(IAssetRepository<TID, UnlockRequirementsEntity<TID, TCommand>> entityRepository, IFoundAssertion foundAssertion, ICanUnlockAssertion<TID, TCommand> canUnlockAssertion, IIDMatchesAssertion<TID> idMatchesAssertion, IQueueAssertion<TID, TCommand> queueAssertion)
+        public EntityUnlockerService(IAssetRepository<TID, UnlockRequirementsEntity<TID, TCommand>> entityRepository, IFoundAssertion foundAssertion, ICanUnlockAssertion<TID, TCommand> canUnlockAssertion, IIDMatchesAssertion<TID> idMatchesAssertion, IQueueAssertion queueAssertion)
         {
             _entityRepository = entityRepository;
             _foundAssertion = foundAssertion;
@@ -68,15 +68,12 @@ namespace IdelPog.Progression.Runtime.System
         private TCommand DequeueComponent(TID id, byte skillLevel, UnlockRequirementsEntity<TID, TCommand> entity)
         {
             bool hasFirst = GetFirstComponent(entity, id, out LevelRequirementComponent<TID, TCommand> firstComponent);
-            if (hasFirst == false)
-            {
-                throw new InvalidOperationException();
-            }
+            _queueAssertion.AssertSuccessfulPeek(hasFirst);
             
             _canUnlockAssertion.AssertCanUnlock(skillLevel, firstComponent.Level, firstComponent);
             
             bool successful = entity.TryDequeue(out LevelRequirementComponent<TID, TCommand> dequeuedComponent);
-            _queueAssertion.AssertSuccessfulDequeue(successful, firstComponent);
+            _queueAssertion.AssertSuccessfulDequeue(successful);
 
             return dequeuedComponent.OnUnlockCommand;
         }

--- a/Progression/Runtime/UnlockRequirementsEntity.cs
+++ b/Progression/Runtime/UnlockRequirementsEntity.cs
@@ -14,11 +14,6 @@ namespace IdelPog.Progression.Runtime
             _levelRequirementStore = GetComponent<QueueComponentStore<LevelRequirementComponent<TID, TCommand>>>();
         }
 
-        public LevelRequirementComponent<TID, TCommand> Peek()
-        {
-            return _levelRequirementStore.Peek();
-        }
-
         public bool TryPeek(out LevelRequirementComponent<TID, TCommand> component)
         { 
             return _levelRequirementStore.TryPeek(out component);

--- a/Progression/Runtime/UnlockRequirementsEntity.cs
+++ b/Progression/Runtime/UnlockRequirementsEntity.cs
@@ -19,6 +19,11 @@ namespace IdelPog.Progression.Runtime
             return _levelRequirementStore.Peek();
         }
 
+        public bool TryPeek(out LevelRequirementComponent<TID, TCommand> component)
+        { 
+            return _levelRequirementStore.TryPeek(out component);
+        }
+
         public bool TryDequeue(out LevelRequirementComponent<TID, TCommand> levelRequirementComponent)
         {
             return _levelRequirementStore.TryDequeue(out levelRequirementComponent);

--- a/Tests/Integration.Tests/HarvestNode/Loot/ItemGenerationTest.cs
+++ b/Tests/Integration.Tests/HarvestNode/Loot/ItemGenerationTest.cs
@@ -50,7 +50,6 @@ namespace IdelPog.Integration.Tests.HarvestNode.Loot
 
             _locationLootCreation = new LocationLootCreation
             {
-                ResourceID = ResourceID.GEM_VEIN,
                 LocationID = LocationID.CAVE,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.RUBY, Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 0, SkipWeight = 0 }

--- a/Tests/Integration.Tests/HarvestNode/Loot/LocationLootCreationTest.cs
+++ b/Tests/Integration.Tests/HarvestNode/Loot/LocationLootCreationTest.cs
@@ -23,7 +23,6 @@ namespace IdelPog.Integration.Tests.HarvestNode.Loot
         {
             _forestLootCreation = new LocationLootCreation
             {
-                ResourceID = ResourceID.ANT_NEST,
                 LocationID = LocationID.FOREST,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.SMALL_INSECTS, Weight = 2 }, new LootTableEntry { ItemID = ItemID.HERBS,  Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 1, SkipWeight = 1 }
@@ -61,7 +60,6 @@ namespace IdelPog.Integration.Tests.HarvestNode.Loot
         {
             Assert.Multiple(() =>
             {
-                Assert.That(response.ResourceID, Is.EqualTo(creation.ResourceID));
                 Assert.That(response.LocationID, Is.EqualTo(creation.LocationID));
                 Assert.That(response.LootTableEntries, Is.EqualTo(creation.LootTableEntries));
             });
@@ -104,7 +102,6 @@ namespace IdelPog.Integration.Tests.HarvestNode.Loot
         {
             LocationLootCreation birchCreation = new()
             {
-                ResourceID = ResourceID.STONE,
                 LocationID = LocationID.CAVE,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.STONE, Weight = 10 }, new LootTableEntry { ItemID = ItemID.DIAMOND, Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 1, SkipWeight = 1 }
@@ -124,7 +121,6 @@ namespace IdelPog.Integration.Tests.HarvestNode.Loot
         {
             LocationLootCreation duplicateCreation = new()
             {
-                ResourceID = ResourceID.LEAF_LITTER,
                 LocationID = LocationID.FOREST,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.EMERALD, Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 1, SkipWeight = 100 }

--- a/Tests/Integration.Tests/HarvestNode/Unlock/HarvestNodeUnlockTest.cs
+++ b/Tests/Integration.Tests/HarvestNode/Unlock/HarvestNodeUnlockTest.cs
@@ -2,6 +2,7 @@
 using IdelPog.Core.Contracts.Enum;
 using IdelPog.Core.Messaging.Exceptions;
 using IdelPog.Core.Validation.Exceptions;
+using IdelPog.HarvestNode.Contracts;
 using IdelPog.HarvestNode.Contracts.Command;
 using IdelPog.HarvestNode.Contracts.Error;
 using IdelPog.HarvestNode.Contracts.Response;
@@ -75,6 +76,80 @@ namespace IdelPog.Integration.Tests.HarvestNode.Unlock
             });
             
             Assert.That(error.HarvestNodeUnlocks, Is.EqualTo(unlocks));
+        }
+        
+        [Test]
+        public void Positive_SendMultipleUnlockCommands_UnlocksWholeQueue()
+        {
+            HarvestNodeRequirementsCreation requirementsCreation = new()
+            {
+                SkillID = SkillID.MINING,
+                HarvestNodeRequirements = 
+                [
+                    new HarvestNodeRequirement { RequiredLevel = 5, OnUnlockCommand = new HarvestNodeUnlockResponse { ResourceID = ResourceID.IRON_CLUSTER, SkillID = SkillID.MINING }},
+                    new HarvestNodeRequirement { RequiredLevel = 10, OnUnlockCommand = new HarvestNodeUnlockResponse { ResourceID = ResourceID.COPPER_CLUSTER, SkillID = SkillID.MINING }},
+                    new HarvestNodeRequirement { RequiredLevel = 15, OnUnlockCommand = new HarvestNodeUnlockResponse { ResourceID = ResourceID.GOLD_CLUSTER, SkillID = SkillID.MINING }}
+                ]
+            };
+            
+            _harvestNodeUnlockDispatcher.DispatchCreations(requirementsCreation);
+            
+            Assert.DoesNotThrow(() => _harvestNodeUnlockDispatcher.DispatchUnlocks(_miningUnlock with { SkillLevel = 5 }));
+            AssertResponseLength(1);
+            AssertResponse(_miningUnlock.SkillID, ResourceID.IRON_CLUSTER, _responseListener.Responses[0]);
+            
+            Assert.DoesNotThrow(() => _harvestNodeUnlockDispatcher.DispatchUnlocks(_miningUnlock with { SkillLevel = 10 }));
+            AssertResponseLength(1);
+            AssertResponse(_miningUnlock.SkillID, ResourceID.COPPER_CLUSTER, _responseListener.Responses[0]);
+            
+            Assert.DoesNotThrow(() => _harvestNodeUnlockDispatcher.DispatchUnlocks(_miningUnlock with { SkillLevel = 15 }));
+            AssertResponseLength(1);
+            AssertResponse(_miningUnlock.SkillID, ResourceID.GOLD_CLUSTER, _responseListener.Responses[0]);
+        }
+
+        [Test]
+        public void Positive_SendSingleUnlockCommand_UnlocksNode_EmptiesQueue()
+        {
+            HarvestNodeRequirementsCreation requirementsCreation = new()
+            {
+                SkillID = SkillID.MINING,
+                HarvestNodeRequirements = 
+                [
+                    new HarvestNodeRequirement { RequiredLevel = 5, OnUnlockCommand = new HarvestNodeUnlockResponse { ResourceID = ResourceID.IRON_CLUSTER, SkillID = SkillID.MINING }}
+                ]
+            };
+            
+            _harvestNodeUnlockDispatcher.DispatchCreations(requirementsCreation);
+            
+            Assert.DoesNotThrow(() => _harvestNodeUnlockDispatcher.DispatchUnlocks(_miningUnlock with { SkillLevel = 5 }));
+            AssertResponseLength(1);
+            AssertResponse(_miningUnlock.SkillID, ResourceID.IRON_CLUSTER, _responseListener.Responses[0]);
+        }
+        
+        [Test]
+        public void Positive_SendUnlockCommand_QueueEmpty_DispatchesNothing()
+        {
+            HarvestNodeRequirementsCreation requirementsCreation = new()
+            {
+                SkillID = SkillID.MINING,
+                HarvestNodeRequirements = 
+                [
+                    new HarvestNodeRequirement { RequiredLevel = 5, OnUnlockCommand = new HarvestNodeUnlockResponse { ResourceID = ResourceID.IRON_CLUSTER, SkillID = SkillID.MINING }}
+                ]
+            };
+            
+            _harvestNodeUnlockDispatcher.DispatchCreations(requirementsCreation);
+            
+            Assert.DoesNotThrow(() => _harvestNodeUnlockDispatcher.DispatchUnlocks(_miningUnlock with { SkillLevel = 5 }));
+            AssertResponseListenerCalled(true);
+
+            // reset the listener after the successful call
+            _responseListener = new ManagedResponseListener<HarvestNodeUnlockResponse>();
+            
+            Assert.DoesNotThrow(() => _harvestNodeUnlockDispatcher.DispatchUnlocks(_miningUnlock with { SkillLevel = 5 }));
+            
+            AssertResponseListenerCalled(false);
+            AssertErrorListenerCalled(false);
         }
 
         [Test]

--- a/Tests/Integration.Tests/Skill/Loot/ItemGenerationTest.cs
+++ b/Tests/Integration.Tests/Skill/Loot/ItemGenerationTest.cs
@@ -50,7 +50,6 @@ namespace IdelPog.Integration.Tests.Skill.Loot
 
             _locationLootCreation = new LocationLootCreation
             {
-                ResourceID = ResourceID.GEM_VEIN,
                 LocationID = LocationID.CAVE,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.RUBY, Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 0, SkipWeight = 0 }

--- a/Tests/Integration.Tests/Skill/Loot/LocationLootCreationTest.cs
+++ b/Tests/Integration.Tests/Skill/Loot/LocationLootCreationTest.cs
@@ -23,7 +23,6 @@ namespace IdelPog.Integration.Tests.Skill.Loot
         {
             _forestLootCreation = new LocationLootCreation
             {
-                ResourceID = ResourceID.ANT_NEST,
                 LocationID = LocationID.FOREST,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.SMALL_INSECTS, Weight = 2 }, new LootTableEntry { ItemID = ItemID.HERBS,  Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 1, SkipWeight = 1 }
@@ -61,7 +60,6 @@ namespace IdelPog.Integration.Tests.Skill.Loot
         {
             Assert.Multiple(() =>
             {
-                Assert.That(response.ResourceID, Is.EqualTo(creation.ResourceID));
                 Assert.That(response.LocationID, Is.EqualTo(creation.LocationID));
                 Assert.That(response.LootTableEntries, Is.EqualTo(creation.LootTableEntries));
             });
@@ -104,7 +102,6 @@ namespace IdelPog.Integration.Tests.Skill.Loot
         {
             LocationLootCreation birchCreation = new()
             {
-                ResourceID = ResourceID.STONE,
                 LocationID = LocationID.CAVE,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.STONE, Weight = 10 }, new LootTableEntry { ItemID = ItemID.DIAMOND, Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 1, SkipWeight = 1 }
@@ -124,7 +121,6 @@ namespace IdelPog.Integration.Tests.Skill.Loot
         {
             LocationLootCreation duplicateCreation = new()
             {
-                ResourceID = ResourceID.LEAF_LITTER,
                 LocationID = LocationID.FOREST,
                 LootTableEntries = [ new LootTableEntry { ItemID = ItemID.EMERALD, Weight = 1 } ],
                 GrantPolicyEntry = new GrantPolicyEntry { GrantWeight = 1, SkipWeight = 100 }

--- a/Tests/Progression.Tests/Assertion/QueueAssertionTest.cs
+++ b/Tests/Progression.Tests/Assertion/QueueAssertionTest.cs
@@ -1,39 +1,41 @@
-﻿using IdelPog.Core.Contracts.Enum;
-using IdelPog.HarvestNode.Contracts.Response;
-using IdelPog.Progression.Assertion;
-using IdelPog.Progression.Assertion.Interface;
+﻿using IdelPog.Progression.Assertion;
 using IdelPog.Progression.Exceptions;
-using IdelPog.Progression.Runtime.Component;
 
 namespace IdelPog.Progression.Tests.Assertion
 {
     [TestFixture]
     public sealed class QueueAssertionTest
     {
-        private IQueueAssertion<SkillID, HarvestNodeUnlockResponse> _queueAssertion;
-        private LevelRequirementComponent<SkillID, HarvestNodeUnlockResponse> _levelRequirementComponent;
+        private QueueAssertion _queueAssertion;
 
         [OneTimeSetUp]
         public void OneTimeSetup()
         {
-            _queueAssertion = new QueueAssertion<SkillID, HarvestNodeUnlockResponse>();
-            
-            _levelRequirementComponent = new LevelRequirementComponent<SkillID, HarvestNodeUnlockResponse>
-            {
-                Level = 1, ID = SkillID.FORAGING, OnUnlockCommand = new HarvestNodeUnlockResponse { ResourceID = ResourceID.BIRCH_TREE, SkillID = SkillID.FORAGING }
-            };
+            _queueAssertion = new QueueAssertion();
         }
 
         [Test]
         public void Positive_AssertSuccessfulDequeue_SuccessfulDequeue_NoThrow()
         {
-            Assert.DoesNotThrow(() => _queueAssertion.AssertSuccessfulDequeue(true, _levelRequirementComponent));
+            Assert.DoesNotThrow(() => _queueAssertion.AssertSuccessfulDequeue(true));
         }
 
         [Test]
         public void Negative_AssertSuccessfulDequeue_UnsuccessfulDequeue_Throws()
         {
-            Assert.Throws<UnsuccessfulDequeueException<SkillID, HarvestNodeUnlockResponse>>(() => _queueAssertion.AssertSuccessfulDequeue(false, _levelRequirementComponent));
+            Assert.Throws<UnsuccessfulDequeueException>(() => _queueAssertion.AssertSuccessfulDequeue(false));
+        }
+        
+        [Test]
+        public void Positive_AssertSuccessfulPeek_SuccessfulPeek_NoThrow()
+        {
+            Assert.DoesNotThrow(() => _queueAssertion.AssertSuccessfulPeek(true));
+        }
+
+        [Test]
+        public void Negative_AssertSuccessfulPeek_UnsuccessfulPeek_Throws()
+        {
+            Assert.Throws<UnsuccessfulPeekException>(() => _queueAssertion.AssertSuccessfulPeek(false));
         }
     }
 }

--- a/Tests/Progression.Tests/Component/QueueComponentStoreTest.cs
+++ b/Tests/Progression.Tests/Component/QueueComponentStoreTest.cs
@@ -40,6 +40,27 @@ namespace IdelPog.Progression.Tests.Component
             
             AssertComponent(frontComponent, 0);
         }
+
+        [Test]
+        public void Positive_TryPeek_GetsFrontComponent()
+        {
+            bool canPeek = _queueComponentStore.TryPeek(out TestComponent frontComponent);
+            
+            Assert.That(canPeek, Is.True);
+            AssertComponent(frontComponent, 0);
+        }
+
+        [Test]
+        public void Positive_TryPeek_NoComponents_ReturnsFalse()
+        {
+            QueueComponentStore<TestComponent> queueComponentStore = new([new TestComponent { Index = 0 }]);
+            bool successful = queueComponentStore.TryDequeue(out TestComponent _);
+            Assert.That(successful, Is.True);
+            
+            bool canPeek = queueComponentStore.TryPeek(out TestComponent _);
+            
+            Assert.That(canPeek, Is.False);
+        }
         
         [Test]
         public void Positive_TryDequeue_DequeuesFrontComponent()

--- a/Tests/Progression.Tests/System/EntityUnlockerServiceTest.cs
+++ b/Tests/Progression.Tests/System/EntityUnlockerServiceTest.cs
@@ -226,14 +226,15 @@ namespace IdelPog.Progression.Tests.System
         }
 
         [Test]
-        public void Negative_UnlockAllAvailable_EmptyEntity_Throws()
+        public void Positive_UnlockAllAvailable_EmptyEntity_ReturnsNothing()
         {
             _harvestNodeUnlockEntity.TryDequeue(out LevelRequirementComponent<SkillID, HarvestNodeUnlockResponse> _);
             
             _repositoryMock.Setup(library => library.Contains(_harvestNodeUnlock.SkillID)).Returns(true);
             _repositoryMock.Setup(library => library.Get(_harvestNodeUnlock.SkillID)).Returns(_harvestNodeUnlockEntity);
 
-            Assert.Throws<InvalidOperationException>(() => _entityUnlockerService.UnlockAllAvailable(_harvestNodeUnlock.SkillID, _harvestNodeUnlock.SkillLevel).ToArray());
+            HarvestNodeUnlockResponse[] responses = _entityUnlockerService.UnlockAllAvailable(_harvestNodeUnlock.SkillID, _harvestNodeUnlock.SkillLevel).ToArray();
+            Assert.That(responses, Has.Length.EqualTo(0));
             
             VerifyRepository(_harvestNodeUnlock.SkillID);
         }

--- a/Tests/Progression.Tests/System/EntityUnlockerServiceTest.cs
+++ b/Tests/Progression.Tests/System/EntityUnlockerServiceTest.cs
@@ -35,7 +35,7 @@ namespace IdelPog.Progression.Tests.System
             _repositoryAsserter = new RepositoryAsserter(new FoundAssertion(), new ObjectNullAssertion(), new UniqueAssertion());
             _repositoryMock = new Mock<IAssetRepository<SkillID, UnlockRequirementsEntity<SkillID, HarvestNodeUnlockResponse>>>();
             
-            _entityUnlockerService = new EntityUnlockerService<SkillID, HarvestNodeUnlockResponse>(_repositoryMock.Object, new FoundAssertion(), new CanUnlockAssertion<SkillID, HarvestNodeUnlockResponse>(), new IDMatchesAssertion<SkillID>(), new QueueAssertion<SkillID, HarvestNodeUnlockResponse>());
+            _entityUnlockerService = new EntityUnlockerService<SkillID, HarvestNodeUnlockResponse>(_repositoryMock.Object, new FoundAssertion(), new CanUnlockAssertion<SkillID, HarvestNodeUnlockResponse>(), new IDMatchesAssertion<SkillID>(), new QueueAssertion());
 
             _harvestNodeUnlock = new HarvestNodeUnlock { SkillID = SkillID.MINING, SkillLevel = 5 };
             _harvestNodeUnlockResponse = new HarvestNodeUnlockResponse { ResourceID = ResourceID.COPPER_CLUSTER, SkillID = SkillID.MINING };
@@ -156,7 +156,7 @@ namespace IdelPog.Progression.Tests.System
             _repositoryMock.Setup(library => library.Contains(_harvestNodeUnlock.SkillID)).Returns(true);
             _repositoryMock.Setup(library => library.Get(_harvestNodeUnlock.SkillID)).Returns(_harvestNodeUnlockEntity);
 
-            Assert.Throws<InvalidOperationException>(() => _entityUnlockerService.Unlock(_harvestNodeUnlock.SkillID, _harvestNodeUnlock.SkillLevel));
+            Assert.Throws<UnsuccessfulPeekException>(() => _entityUnlockerService.Unlock(_harvestNodeUnlock.SkillID, _harvestNodeUnlock.SkillLevel));
             
             VerifyRepository(_harvestNodeUnlock.SkillID);
         }


### PR DESCRIPTION
Exposes the Queue TryPeek method in QueueComponentStore. The EntityUnlockerService now uses TryPeek instead of Peek everywhere. This fixes an issue where it was impossible to unlock the last queue element.

Also removes ResourceID from LocationLootCreation, no idea why this was there. It wasn't used and made the command confusing.